### PR TITLE
feat: deprecate eslintConfigForTsDataForge

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -176,6 +176,9 @@ export default [
 
   ...eslintConfigForReact(['test/**/*.{mts,tsx}']),
 
+  // Kept until eslint-config-typed's next major; the rules now live in the
+  // standalone `eslint-plugin-ts-data-forge` package.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   eslintConfigForTsDataForge(['test/**/*.{mts,tsx}']),
 
   {

--- a/src/configs/ts-data-forge.mts
+++ b/src/configs/ts-data-forge.mts
@@ -1,6 +1,32 @@
 import { eslintTsDataForgeRules } from '../rules/index.mjs';
 import { defineKnownRules, type FlatConfig } from '../types/index.mjs';
 
+/**
+ * @deprecated Use the standalone
+ * [`eslint-plugin-ts-data-forge`](https://www.npmjs.com/package/eslint-plugin-ts-data-forge)
+ * package instead. It contains the same rules but is versioned and released
+ * together with `ts-data-forge`, so the rules always match the `ts-data-forge`
+ * version you use. Register the plugin and enable the rules directly:
+ *
+ * ```js
+ * // eslint.config.mjs
+ * import tsDataForge from 'eslint-plugin-ts-data-forge';
+ *
+ * export default [
+ *   {
+ *     plugins: { 'ts-data-forge': tsDataForge },
+ *     rules: {
+ *       'ts-data-forge/prefer-arr-is-non-empty': 'error',
+ *       'ts-data-forge/prefer-is-record-and-has-key': 'error',
+ *       // ...enable the rules you want
+ *     },
+ *   },
+ * ];
+ * ```
+ *
+ * This helper (and the bundled `ts-data-forge` rules) will be removed from
+ * `eslint-config-typed` in the next major version.
+ */
 export const eslintConfigForTsDataForge = (
   files?: readonly string[],
 ): FlatConfig =>


### PR DESCRIPTION
The ts-data-forge rules now ship as the standalone, independently
versioned `eslint-plugin-ts-data-forge` package. Mark
`eslintConfigForTsDataForge` as @deprecated with a migration example
pointing at the new plugin. The helper and the bundled ts-data-forge
rules will be removed in the next major version; the repo's own usage is
suppressed until then.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M7rgiT61D582uZRemdkEhs