### PR TITLE
feat: add ts-restrictions/no-string-spread rule

### DIFF
--- a/src/plugins/ts-restrictions/rules/no-string-spread.mts
+++ b/src/plugins/ts-restrictions/rules/no-string-spread.mts
@@ -1,0 +1,118 @@
+import { ESLintUtils, type TSESLint } from '@typescript-eslint/utils';
+import * as ts from 'typescript';
+
+type Options = readonly [];
+
+type MessageIds = 'noStringSpread';
+
+/**
+ * Deferred (non-concrete) type flags whose actual members are only known once
+ * the type is instantiated. They are reduced to their base constraint before
+ * checking whether they are string-like.
+ */
+const DEFERRED_TYPE_FLAGS =
+  ts.TypeFlags.TypeParameter |
+  ts.TypeFlags.IndexedAccess |
+  ts.TypeFlags.Conditional |
+  ts.TypeFlags.Substitution;
+
+/**
+ * Disallow spreading a `string` value with the spread operator `...`.
+ *
+ * ## Why
+ *
+ * Spreading a string iterates it into its individual characters, so
+ * `[...someString]` (or `f(...someString)`) evaluates to a `string[]` — the
+ * *exact same result type* as spreading an actual `string[]`. That makes an
+ * accidental string spread silent: neither the reader nor the type checker can
+ * tell `[...anArray]` from `[...aString]` by the result type alone, so a bug
+ * where an array was expected but a `string` slipped in goes unnoticed.
+ *
+ * ## Why not simply "allow array / object types only"
+ *
+ * The naive framing — "only permit `...` on arrays or objects" — would also
+ * reject perfectly idiomatic spreads of other iterables (`Set`, `Map`,
+ * `Map.prototype.keys()`, generators, `NodeList`, typed arrays, `arguments`,
+ * …), which have no equivalent silent hazard. And TypeScript *already* rejects
+ * spreading a non-iterable primitive such as `number` / `boolean` in an
+ * iterable position. The only case TypeScript accepts yet is genuinely
+ * error-prone is `string`, so that is exactly what this rule targets.
+ *
+ * If a character split is really intended, spell it out with
+ * `Array.from(str)` (identical to the spread, code-point aware) or
+ * `str.split('')`.
+ */
+export const noStringSpread: TSESLint.RuleModule<MessageIds, Options> = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow spreading a `string` (e.g. `[...str]`), which silently splits it into characters and yields a `string[]` indistinguishable from spreading an array',
+    },
+    schema: [],
+    messages: {
+      noStringSpread:
+        'Spreading a `string` splits it into individual characters and yields a `string[]` indistinguishable from spreading an array, so accidental string spreads go unnoticed. Spread an array or object instead; if a character split is intended, make it explicit with `Array.from(str)`.',
+    },
+  },
+
+  create: (context) => {
+    const parserServices = ESLintUtils.getParserServices(context);
+
+    const checker = parserServices.program.getTypeChecker();
+
+    /**
+     * Returns `true` if the given type could be spread as a string (it is
+     * string-like, or a union / intersection with a string-like constituent).
+     *
+     * - `any` / `unknown` are treated conservatively as *not* string-like:
+     *   they cannot be proven to be a string, and flagging them would fire on
+     *   every untyped spread.
+     * - Unions are flagged when *any* branch is string-like, because such a
+     *   branch reintroduces the silent char-split hazard.
+     * - Intersections are flagged when *any* constituent is string-like: a
+     *   branded string (`string & Brand`) is still a `string` at runtime.
+     * - A deferred type (type parameter, indexed access, conditional, …) is
+     *   reduced to its base constraint; one with no resolvable constraint is
+     *   left alone to avoid false positives on unconstrained generics.
+     */
+    // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+    const isStringLikeType = (type: ts.Type): boolean => {
+      if ((type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0) {
+        return false;
+      }
+
+      if (type.isUnion() || type.isIntersection()) {
+        return type.types.some(isStringLikeType);
+      }
+
+      if ((type.flags & DEFERRED_TYPE_FLAGS) !== 0) {
+        const constraint = checker.getBaseConstraintOfType(type);
+
+        return constraint !== undefined && isStringLikeType(constraint);
+      }
+
+      return (type.flags & ts.TypeFlags.StringLike) !== 0;
+    };
+
+    return {
+      // `SpreadElement` covers every value-spread position: array literals
+      // (`[...x]`), call / new arguments (`f(...x)`), and object literals
+      // (`{...x}`). Destructuring rest (`[a, ...rest]`, `{ ...rest }`) is a
+      // `RestElement` / `RestType` and is intentionally not matched.
+      SpreadElement: (node) => {
+        const argTsNode = parserServices.esTreeNodeToTSNodeMap.get(
+          node.argument,
+        );
+
+        if (!isStringLikeType(checker.getTypeAtLocation(argTsNode))) return;
+
+        context.report({
+          node,
+          messageId: 'noStringSpread',
+        });
+      },
+    };
+  },
+  defaultOptions: [],
+} as const;

--- a/src/plugins/ts-restrictions/rules/no-string-spread.test.mts
+++ b/src/plugins/ts-restrictions/rules/no-string-spread.test.mts
@@ -1,0 +1,175 @@
+import parser from '@typescript-eslint/parser';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import dedent from 'dedent';
+import { noStringSpread } from './no-string-spread.mjs';
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser,
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      projectService: {
+        allowDefaultProject: ['*.ts*'],
+      },
+      tsconfigRootDir: `${import.meta.dirname}/../../../..`,
+    },
+  },
+});
+
+describe('no-string-spread', () => {
+  tester.run('no-string-spread', noStringSpread, {
+    valid: [
+      {
+        name: 'spreading an array into an array literal',
+        code: dedent`
+          declare const xs: readonly number[];
+          const ys = [...xs];
+        `,
+      },
+      {
+        name: 'spreading a tuple into an array literal',
+        code: dedent`
+          declare const xs: readonly [number, string];
+          const ys = [...xs];
+        `,
+      },
+      {
+        name: 'spreading an array into a function call',
+        code: dedent`
+          declare const xs: readonly number[];
+          const m = Math.max(...xs);
+        `,
+      },
+      {
+        name: 'spreading an object into an object literal',
+        code: dedent`
+          declare const obj: { readonly a: number; readonly b: number };
+          const clone = { ...obj };
+        `,
+      },
+      {
+        name: 'spreading a Set is a legitimate iterable spread',
+        code: dedent`
+          declare const s: ReadonlySet<number>;
+          const ys = [...s];
+        `,
+      },
+      {
+        name: 'spreading a Map is a legitimate iterable spread',
+        code: dedent`
+          declare const m: ReadonlyMap<string, number>;
+          const entries = [...m];
+        `,
+      },
+      {
+        name: 'spreading a generic iterable is not a string',
+        code: dedent`
+          declare const it: Iterable<number>;
+          const ys = [...it];
+        `,
+      },
+      {
+        name: 'any is treated conservatively and not flagged',
+        code: dedent`
+          declare const x: any;
+          const ys = [...x];
+        `,
+      },
+      {
+        name: 'array destructuring rest is not a value spread',
+        code: dedent`
+          declare const xs: readonly number[];
+          const [first, ...rest] = xs;
+        `,
+      },
+      {
+        name: 'object destructuring rest is not a value spread',
+        code: dedent`
+          declare const obj: { readonly a: number; readonly b: number };
+          const { a, ...others } = obj;
+        `,
+      },
+      {
+        name: 'spreading an array of strings is fine (not a string itself)',
+        code: dedent`
+          declare const xs: readonly string[];
+          const ys = [...xs];
+        `,
+      },
+      {
+        name: 'unconstrained generic is left alone',
+        code: dedent`
+          const f = <T>(xs: readonly T[]): readonly T[] => [...xs];
+        `,
+      },
+    ],
+    invalid: [
+      {
+        name: 'spreading a string into an array literal',
+        code: dedent`
+          declare const s: string;
+          const chars = [...s];
+        `,
+        errors: [{ messageId: 'noStringSpread' }],
+      },
+      {
+        name: 'spreading a string into a function call',
+        code: dedent`
+          declare const s: string;
+          declare function f(...args: readonly string[]): void;
+          f(...s);
+        `,
+        errors: [{ messageId: 'noStringSpread' }],
+      },
+      {
+        name: 'spreading a string into an object literal',
+        code: dedent`
+          declare const s: string;
+          const o = { ...s };
+        `,
+        errors: [{ messageId: 'noStringSpread' }],
+      },
+      {
+        name: 'spreading a string literal type',
+        code: dedent`
+          declare const s: 'abc';
+          const chars = [...s];
+        `,
+        errors: [{ messageId: 'noStringSpread' }],
+      },
+      {
+        name: 'spreading a template literal type',
+        code: dedent`
+          declare const s: \`id_\${string}\`;
+          const chars = [...s];
+        `,
+        errors: [{ messageId: 'noStringSpread' }],
+      },
+      {
+        name: 'spreading a union that includes string is still flagged',
+        code: dedent`
+          declare const s: string | readonly string[];
+          const ys = [...s];
+        `,
+        errors: [{ messageId: 'noStringSpread' }],
+      },
+      {
+        name: 'spreading a branded string (intersection) is flagged',
+        code: dedent`
+          type UserId = string & { readonly __brand: unique symbol };
+          declare const s: UserId;
+          const chars = [...s];
+        `,
+        errors: [{ messageId: 'noStringSpread' }],
+      },
+      {
+        name: 'spreading a generic constrained to string is flagged',
+        code: dedent`
+          const f = <T extends string>(s: T): readonly string[] => [...s];
+        `,
+        errors: [{ messageId: 'noStringSpread' }],
+      },
+    ],
+  });
+});

--- a/src/plugins/ts-restrictions/rules/rules.mts
+++ b/src/plugins/ts-restrictions/rules/rules.mts
@@ -2,6 +2,7 @@ import { type ESLintPlugin } from '../../../types/index.mjs';
 import { checkDestructuringCompleteness } from './check-destructuring-completeness.mjs';
 import { noRestrictedCastName } from './no-restricted-cast-name.mjs';
 import { noRestrictedSyntax } from './no-restricted-syntax.mjs';
+import { noStringSpread } from './no-string-spread.mjs';
 import { noUnnecessaryArrayFrom } from './no-unnecessary-array-from.mjs';
 import { noUnnecessaryCoalesceUndefined } from './no-unnecessary-coalesce-undefined.mjs';
 import { preferNonMutatingArrayMethod } from './prefer-non-mutating-array-method.mjs';
@@ -10,6 +11,7 @@ export const tsRestrictionsRules = {
   'check-destructuring-completeness': checkDestructuringCompleteness,
   'no-restricted-cast-name': noRestrictedCastName,
   'no-restricted-syntax': noRestrictedSyntax,
+  'no-string-spread': noStringSpread,
   'no-unnecessary-array-from': noUnnecessaryArrayFrom,
   'no-unnecessary-coalesce-undefined': noUnnecessaryCoalesceUndefined,
   'prefer-non-mutating-array-method': preferNonMutatingArrayMethod,

--- a/src/rules/eslint-ts-restrictions-rules.mts
+++ b/src/rules/eslint-ts-restrictions-rules.mts
@@ -6,6 +6,7 @@ import {
 export const eslintTsRestrictionsRules = {
   'ts-restrictions/no-restricted-syntax': 'off',
   'ts-restrictions/no-restricted-cast-name': 'off',
+  'ts-restrictions/no-string-spread': 'error',
   'ts-restrictions/no-unnecessary-array-from': 'error',
   'ts-restrictions/no-unnecessary-coalesce-undefined': 'error',
   'ts-restrictions/prefer-non-mutating-array-method': 'error',

--- a/src/types/rules/eslint-ts-restrictions-rules.mts
+++ b/src/types/rules/eslint-ts-restrictions-rules.mts
@@ -236,6 +236,20 @@ namespace NoRestrictedSyntax {
 }
 
 /**
+ * @description Disallow spreading a `string` (e.g. `[...str]`), which silently splits it into characters and yields a `string[]` indistinguishable from spreading an array
+ *
+ *  ```md
+ *  | key        | value   |
+ *  | :--------- | :------ |
+ *  | type       | problem |
+ *  | deprecated | false   |
+ *  ```
+ */
+namespace NoStringSpread {
+  export type RuleEntry = Linter.StringSeverity;
+}
+
+/**
  * @description Disallow wrapping an array in `Array.from()` before a non-mutating array method (e.g. `Array.from(x).toSorted()`), since the method already returns a new array
  *
  *  ```md
@@ -284,6 +298,7 @@ export type EslintTsRestrictionsRules = Readonly<{
   'ts-restrictions/check-destructuring-completeness': CheckDestructuringCompleteness.RuleEntry;
   'ts-restrictions/no-restricted-cast-name': NoRestrictedCastName.RuleEntry;
   'ts-restrictions/no-restricted-syntax': NoRestrictedSyntax.RuleEntry;
+  'ts-restrictions/no-string-spread': NoStringSpread.RuleEntry;
   'ts-restrictions/no-unnecessary-array-from': NoUnnecessaryArrayFrom.RuleEntry;
   'ts-restrictions/no-unnecessary-coalesce-undefined': NoUnnecessaryCoalesceUndefined.RuleEntry;
   'ts-restrictions/prefer-non-mutating-array-method': PreferNonMutatingArrayMethod.RuleEntry;


### PR DESCRIPTION
Disallow spreading a `string` with the spread operator (e.g. `[...str]`,
`f(...str)`, `{ ...str }`). Spreading a string splits it into individual
characters and yields a `string[]` that is type-indistinguishable from
spreading an actual array, so accidental string spreads go unnoticed.

Rather than a blanket "arrays/objects only" restriction — which would also
reject idiomatic spreads of other iterables (Set, Map, generators,
NodeList, typed arrays, ...) that carry no such silent hazard, and which
TypeScript already guards against for non-iterable primitives like number
/ boolean — the rule targets the one case TypeScript accepts yet is
genuinely error-prone: `string`. Detection is type-aware and handles
string literal / template-literal types, unions with a string branch,
branded strings (intersections), and generics via their base constraint.

Enabled as `error` in the shared config.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PjAssUnScuMmq28dji324v