### PR TITLE
feat(ts-restrictions): add prefer-curried-call rule

### DIFF
--- a/scripts/gen-eslint-rules/functions/generate-rules-type-core.mts
+++ b/scripts/gen-eslint-rules/functions/generate-rules-type-core.mts
@@ -296,9 +296,7 @@ const createResult = async (
         default: {
           mut_resultToWrite.push(...rawSchemaToString(schemaToPrint));
 
-          const schemasWithDefaults = schema.map((s) =>
-            addDefaultValuesToDescription(s),
-          );
+          const schemasWithDefaults = schema.map(addDefaultValuesToDescription);
 
           /* e.g. "export type Options = { ... };" */
           const optionsTypeList: readonly string[] = await Promise.all(

--- a/src/plugins/total-functions/rules/no-partial-division.mts
+++ b/src/plugins/total-functions/rules/no-partial-division.mts
@@ -35,12 +35,12 @@ export const noPartialDivision = createRule({
 
         return (
           numberLiteralParts.length > 0 &&
-          numberLiteralParts.every((t) => isSafeDenominator(t))
+          numberLiteralParts.every(isSafeDenominator)
         );
       }
 
       if (type.isUnion()) {
-        return unionTypeParts(type).every((t) => isSafeDenominator(t));
+        return unionTypeParts(type).every(isSafeDenominator);
       }
 
       return (

--- a/src/plugins/ts-restrictions/rules/prefer-curried-call.mts
+++ b/src/plugins/ts-restrictions/rules/prefer-curried-call.mts
@@ -1,0 +1,393 @@
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  type TSESLint,
+  type TSESTree,
+} from '@typescript-eslint/utils';
+import * as ts from 'typescript';
+
+type Options = readonly [];
+
+type MessageIds = 'useFunctionDirectly' | 'useCurriedForm';
+
+/**
+ * Replaces a redundant arrow wrapper around a function call with a point-free
+ * form, using the callee's curried version when one exists:
+ *
+ * - `(a) => f(a)` → `f` — only when `f` is effectively unary, so passing it
+ *   directly cannot change behavior even when the wrapper is used as a
+ *   multi-argument callback (`arr.map((a) => f(a))` → `arr.map(f)`). This is
+ *   what keeps the classic `arr.map((s) => parseInt(s))` case (where `parseInt`
+ *   also reads the index) from being rewritten.
+ * - `(a) => f(a, ...rest)` → `f(...rest)` — only when `f` has a curried call
+ *   signature accepting `...rest` and returning a one-argument function, i.e.
+ *   a genuine curried version (`(a) => toPushed(a, x)` → `toPushed(x)`).
+ *
+ * The arrow's single parameter must appear exactly once, as the first argument
+ * of the call, so dropping the wrapper is behavior-preserving.
+ */
+export const preferCurriedCall: TSESLint.RuleModule<MessageIds, Options> = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Replace a redundant arrow wrapper with the function itself (`(a) => f(a)` → `f`) or, when the callee has a curried version, its curried form (`(a) => f(a, ...rest)` → `f(...rest)`).',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      useFunctionDirectly:
+        'Replace the redundant arrow wrapper `{{original}}` with `{{replacement}}`.',
+      useCurriedForm:
+        'Replace the arrow wrapper `{{original}}` with the curried call `{{replacement}}`.',
+    },
+  },
+
+  create: (context) => {
+    const sourceCode = context.sourceCode;
+
+    const services = ESLintUtils.getParserServices(context);
+
+    const checker = services.program.getTypeChecker();
+
+    const getType = (
+      // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+      node: TSESTree.Node,
+    ): ts.Type =>
+      checker.getTypeAtLocation(services.esTreeNodeToTSNodeMap.get(node));
+
+    /**
+     * `true` when `node` refers to a module/namespace object (e.g. a namespace
+     * imported as `Arr`). Referencing `Namespace.fn` as a value is safe because
+     * namespace members do not depend on a dynamic `this`, unlike instance
+     * methods (`obj.method`), which would lose their receiver.
+     */
+    const isNamespaceObject = (
+      // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+      node: TSESTree.Node,
+    ): boolean => {
+      const symbol = checker.getSymbolAtLocation(
+        services.esTreeNodeToTSNodeMap.get(node),
+      );
+
+      if (symbol === undefined) return false;
+
+      const resolved =
+        (symbol.flags & ts.SymbolFlags.Alias) !== 0
+          ? checker.getAliasedSymbol(symbol)
+          : symbol;
+
+      return (
+        (resolved.flags &
+          (ts.SymbolFlags.ValueModule | ts.SymbolFlags.NamespaceModule)) !==
+        0
+      );
+    };
+
+    /**
+     * For the eta reduction `(a) => f(a)` → `f`, the callee must be safe to
+     * reference as a bare value: a plain identifier (a standalone function) or
+     * a namespace member (`Arr.isNonEmpty`). Instance-method callees are
+     * rejected because the point-free form would drop their `this`.
+     */
+    const isEtaSafeCallee = (
+      // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+      callee: TSESTree.Expression,
+    ): boolean => {
+      if (callee.type === AST_NODE_TYPES.Identifier) return true;
+
+      if (callee.type === AST_NODE_TYPES.MemberExpression) {
+        return !callee.optional && isNamespaceObject(callee.object);
+      }
+
+      return false;
+    };
+
+    /**
+     * `true` when the arrow's single parameter is referenced exactly once, at
+     * `argument` — so it appears neither in the callee nor in any other
+     * argument, and dropping the wrapper cannot change behavior.
+     */
+    const paramUsedOnlyAt = (
+      // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+      node: TSESTree.ArrowFunctionExpression,
+      paramName: string,
+      // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+      argument: TSESTree.Node,
+    ): boolean => {
+      const scope = sourceCode.getScope(node);
+
+      const variable = scope.variables.find((v) => v.name === paramName);
+
+      if (variable === undefined) return false;
+
+      const [reference] = variable.references;
+
+      return (
+        variable.references.length === 1 && reference?.identifier === argument
+      );
+    };
+
+    return {
+      ArrowFunctionExpression: (node) => {
+        if (node.async || node.params.length !== 1) return;
+
+        const [param] = node.params;
+
+        if (
+          param?.type !== AST_NODE_TYPES.Identifier ||
+          param.typeAnnotation !== undefined
+        ) {
+          return;
+        }
+
+        if (node.body.type !== AST_NODE_TYPES.CallExpression) return;
+
+        const call = node.body;
+
+        if (call.optional) return;
+
+        const [firstArg, ...restArgs] = call.arguments;
+
+        if (
+          firstArg?.type !== AST_NODE_TYPES.Identifier ||
+          firstArg.name !== param.name
+        ) {
+          return;
+        }
+
+        // A spread in the remaining arguments breaks positional arg counting.
+        if (restArgs.some((arg) => arg.type === AST_NODE_TYPES.SpreadElement)) {
+          return;
+        }
+
+        if (!paramUsedOnlyAt(node, param.name, firstArg)) return;
+
+        const calleeType = getType(call.callee);
+
+        const calleeText = sourceCode.getText(call.callee);
+
+        if (restArgs.length === 0) {
+          // `(a) => f(a)` → `f`
+          if (
+            !isEtaSafeCallee(call.callee) ||
+            !isEffectivelyUnary(calleeType)
+          ) {
+            return;
+          }
+
+          context.report({
+            node,
+            messageId: 'useFunctionDirectly',
+            data: {
+              original: sourceCode.getText(node),
+              replacement: calleeText,
+            },
+            fix: (fixer) => fixer.replaceText(node, calleeText),
+          });
+
+          return;
+        }
+
+        // `(a) => f(a, ...rest)` → `f(...rest)`
+        // Re-evaluating a side-effecting argument once (at currying time)
+        // instead of on every call would change behavior, so require the
+        // remaining arguments to be free of observable side effects.
+        if (
+          !restArgs.every(isPureExpression) ||
+          !hasCurriedSignature(calleeType, restArgs.length)
+        ) {
+          return;
+        }
+
+        const replacement = `${calleeText}(${restArgs
+          .map((arg) => sourceCode.getText(arg))
+          .join(', ')})`;
+
+        context.report({
+          node,
+          messageId: 'useCurriedForm',
+          data: {
+            original: sourceCode.getText(node),
+            replacement,
+          },
+          fix: (fixer) => fixer.replaceText(node, replacement),
+        });
+      },
+    };
+  },
+  defaultOptions: [],
+} as const;
+
+/**
+ * `true` when every call signature of `type` accepts at most one argument, so
+ * `(a) => f(a)` is equivalent to `f` even when the wrapper is used as a
+ * multi-argument callback (the extra positional arguments are ignored either
+ * way). Requires at least one call signature.
+ */
+const isEffectivelyUnary = (
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  type: ts.Type,
+): boolean => {
+  const signatures = type.getCallSignatures();
+
+  return (
+    signatures.length > 0 &&
+    signatures.every((signature) => signatureMaxArgs(signature) <= 1)
+  );
+};
+
+/**
+ * `true` when `type` has a curried call signature accepting exactly
+ * `restCount` arguments and returning a function that accepts one argument —
+ * i.e. `f(...rest)` is the curried form of `f(a, ...rest)`.
+ */
+const hasCurriedSignature = (
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  type: ts.Type,
+  restCount: number,
+): boolean =>
+  type.getCallSignatures().some((signature) => {
+    if (!isCallableWith(signature, restCount)) return false;
+
+    return signature
+      .getReturnType()
+      .getCallSignatures()
+      .some((inner) => isCallableWith(inner, 1));
+  });
+
+const isCallableWith = (
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  signature: ts.Signature,
+  argCount: number,
+): boolean =>
+  signatureMinArgs(signature) <= argCount &&
+  argCount <= signatureMaxArgs(signature);
+
+/** The largest number of positional arguments the signature accepts. */
+const signatureMaxArgs = (
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  signature: ts.Signature,
+): number => {
+  const params = signature.getParameters();
+
+  const last = params.at(-1);
+
+  return last !== undefined && isRestParameter(last)
+    ? Number.POSITIVE_INFINITY
+    : params.length;
+};
+
+/** The number of leading required parameters (before any optional/rest). */
+const signatureMinArgs = (
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  signature: ts.Signature,
+): number => {
+  const firstOptional = signature
+    .getParameters()
+    .findIndex(isOptionalParameter);
+
+  return firstOptional === -1
+    ? signature.getParameters().length
+    : firstOptional;
+};
+
+/** A parameter that collects the rest of the arguments (`...args`). */
+const isRestParameter = (
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  symbol: ts.Symbol,
+): boolean => {
+  const declaration = symbol.valueDeclaration ?? symbol.declarations?.[0];
+
+  return (
+    declaration !== undefined &&
+    ts.isParameter(declaration) &&
+    declaration.dotDotDotToken !== undefined
+  );
+};
+
+/** A parameter that may be omitted (`x?`, `x = ...`) or is a rest parameter. */
+const isOptionalParameter = (
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  symbol: ts.Symbol,
+): boolean => {
+  const declaration = symbol.valueDeclaration ?? symbol.declarations?.[0];
+
+  return (
+    declaration !== undefined &&
+    ts.isParameter(declaration) &&
+    (declaration.questionToken !== undefined ||
+      declaration.initializer !== undefined ||
+      declaration.dotDotDotToken !== undefined)
+  );
+};
+
+/**
+ * A conservative purity approximation: `true` only for expressions whose
+ * evaluation has no observable side effects and does not depend on evaluation
+ * count (so hoisting it out of the wrapper is safe). Anything not recognized
+ * (calls, `new`, `await`, assignments, updates) is treated as impure.
+ */
+const isPureExpression = (
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  node: TSESTree.Node,
+): boolean => {
+  if (
+    node.type === AST_NODE_TYPES.Literal ||
+    node.type === AST_NODE_TYPES.Identifier ||
+    node.type === AST_NODE_TYPES.ThisExpression ||
+    node.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+    node.type === AST_NODE_TYPES.FunctionExpression
+  ) {
+    return true;
+  }
+
+  if (node.type === AST_NODE_TYPES.TemplateLiteral) {
+    return node.expressions.every(isPureExpression);
+  }
+
+  if (node.type === AST_NODE_TYPES.MemberExpression) {
+    return node.computed
+      ? isPureExpression(node.object) && isPureExpression(node.property)
+      : isPureExpression(node.object);
+  }
+
+  if (node.type === AST_NODE_TYPES.UnaryExpression) {
+    return node.operator !== 'delete' && isPureExpression(node.argument);
+  }
+
+  if (
+    node.type === AST_NODE_TYPES.BinaryExpression ||
+    node.type === AST_NODE_TYPES.LogicalExpression
+  ) {
+    return isPureExpression(node.left) && isPureExpression(node.right);
+  }
+
+  if (node.type === AST_NODE_TYPES.ConditionalExpression) {
+    return (
+      isPureExpression(node.test) &&
+      isPureExpression(node.consequent) &&
+      isPureExpression(node.alternate)
+    );
+  }
+
+  if (node.type === AST_NODE_TYPES.ArrayExpression) {
+    return node.elements.every(
+      (element) =>
+        element === null ||
+        (element.type !== AST_NODE_TYPES.SpreadElement &&
+          isPureExpression(element)),
+    );
+  }
+
+  if (node.type === AST_NODE_TYPES.ObjectExpression) {
+    return node.properties.every(
+      (property) =>
+        property.type === AST_NODE_TYPES.Property &&
+        !property.computed &&
+        isPureExpression(property.value),
+    );
+  }
+
+  return false;
+};

--- a/src/plugins/ts-restrictions/rules/prefer-curried-call.test.mts
+++ b/src/plugins/ts-restrictions/rules/prefer-curried-call.test.mts
@@ -1,0 +1,213 @@
+import parser from '@typescript-eslint/parser';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import dedent from 'dedent';
+import { preferCurriedCall } from './prefer-curried-call.mjs';
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser,
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      projectService: {
+        allowDefaultProject: ['*.ts*'],
+      },
+      tsconfigRootDir: `${import.meta.dirname}/../../../..`,
+    },
+  },
+});
+
+/** A curried, data-first function declaration shared by many test cases. */
+const curriedDecls = dedent`
+  declare function toPushed<Ar extends readonly unknown[], V>(
+    array: Ar,
+    v: V,
+  ): readonly [...Ar, V];
+  declare function toPushed<V>(
+    v: V,
+  ): <Ar extends readonly unknown[]>(array: Ar) => readonly [...Ar, V];
+
+  declare function take<Ar extends readonly unknown[]>(
+    array: Ar,
+    n: number,
+  ): Ar;
+  declare function take(
+    n: number,
+  ): <Ar extends readonly unknown[]>(array: Ar) => Ar;
+
+  declare namespace Arr {
+    function toPushed<Ar extends readonly unknown[], V>(
+      array: Ar,
+      v: V,
+    ): readonly [...Ar, V];
+    function toPushed<V>(
+      v: V,
+    ): <Ar extends readonly unknown[]>(array: Ar) => readonly [...Ar, V];
+
+    function isNonEmpty<E>(array: readonly E[]): boolean;
+  }
+
+  declare function isNonEmpty<E>(array: readonly E[]): boolean;
+`;
+
+describe('prefer-curried-call', () => {
+  tester.run('prefer-curried-call', preferCurriedCall, {
+    valid: [
+      {
+        name: 'non-curried multi-argument function is left untouched',
+        code: dedent`
+          declare function add(a: number, b: number): number;
+          declare const xs: readonly number[];
+          const ys = xs.map((a) => add(a, 1));
+        `,
+      },
+      {
+        name: 'eta reduction is skipped when the function is not unary (parseInt/radix footgun)',
+        code: dedent`
+          declare const xs: readonly string[];
+          const ys = xs.map((a) => parseInt(a));
+        `,
+      },
+      {
+        name: 'eta reduction is skipped for instance methods (would drop `this`)',
+        code: dedent`
+          declare const obj: { method(a: number): boolean };
+          declare const xs: readonly number[];
+          const ys = xs.map((a) => obj.method(a));
+        `,
+      },
+      {
+        name: 'parameter used more than once is left untouched',
+        code: dedent`
+          ${curriedDecls}
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map((a) => toPushed(a, a));
+        `,
+      },
+      {
+        name: 'parameter that is not the first argument is left untouched',
+        code: dedent`
+          ${curriedDecls}
+          declare const x: readonly number[];
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map((a) => toPushed(x, a));
+        `,
+      },
+      {
+        name: 'impure remaining argument is left untouched (evaluation timing)',
+        code: dedent`
+          ${curriedDecls}
+          declare function sideEffect(): number;
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map((a) => toPushed(a, sideEffect()));
+        `,
+      },
+      {
+        name: 'annotated parameter is left untouched',
+        code: dedent`
+          ${curriedDecls}
+          const f = (a: readonly number[]) => toPushed(a, 5);
+        `,
+      },
+      {
+        name: 'async wrapper is left untouched',
+        code: dedent`
+          declare function load<E>(array: readonly E[]): Promise<readonly E[]>;
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map(async (a) => load(a));
+        `,
+      },
+      {
+        name: 'already-curried callee (a call expression) is left untouched for eta',
+        code: dedent`
+          ${curriedDecls}
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map((a) => take(3)(a));
+        `,
+      },
+      {
+        name: 'multi-argument arrow is left untouched',
+        code: dedent`
+          ${curriedDecls}
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map((a, i) => toPushed(a, i));
+        `,
+      },
+    ],
+
+    invalid: [
+      {
+        name: 'eta reduction of a standalone unary function',
+        code: dedent`
+          ${curriedDecls}
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map((a) => isNonEmpty(a));
+        `,
+        output: dedent`
+          ${curriedDecls}
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map(isNonEmpty);
+        `,
+        errors: [{ messageId: 'useFunctionDirectly' }],
+      },
+      {
+        name: 'eta reduction of a namespace-member unary function',
+        code: dedent`
+          ${curriedDecls}
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map((a) => Arr.isNonEmpty(a));
+        `,
+        output: dedent`
+          ${curriedDecls}
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map(Arr.isNonEmpty);
+        `,
+        errors: [{ messageId: 'useFunctionDirectly' }],
+      },
+      {
+        name: 'curried form of a standalone two-argument function',
+        code: dedent`
+          ${curriedDecls}
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map((a) => toPushed(a, 5));
+        `,
+        output: dedent`
+          ${curriedDecls}
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map(toPushed(5));
+        `,
+        errors: [{ messageId: 'useCurriedForm' }],
+      },
+      {
+        name: 'curried form of a namespace-member function (the motivating example)',
+        code: dedent`
+          ${curriedDecls}
+          declare const newElem: number;
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map((a) => Arr.toPushed(a, newElem));
+        `,
+        output: dedent`
+          ${curriedDecls}
+          declare const newElem: number;
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map(Arr.toPushed(newElem));
+        `,
+        errors: [{ messageId: 'useCurriedForm' }],
+      },
+      {
+        name: 'curried form with a counted argument (take)',
+        code: dedent`
+          ${curriedDecls}
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map((a) => take(a, 3));
+        `,
+        output: dedent`
+          ${curriedDecls}
+          declare const xss: readonly (readonly number[])[];
+          const ys = xss.map(take(3));
+        `,
+        errors: [{ messageId: 'useCurriedForm' }],
+      },
+    ],
+  });
+});

--- a/src/plugins/ts-restrictions/rules/rules.mts
+++ b/src/plugins/ts-restrictions/rules/rules.mts
@@ -5,6 +5,7 @@ import { noRestrictedSyntax } from './no-restricted-syntax.mjs';
 import { noStringSpread } from './no-string-spread.mjs';
 import { noUnnecessaryArrayFrom } from './no-unnecessary-array-from.mjs';
 import { noUnnecessaryCoalesceUndefined } from './no-unnecessary-coalesce-undefined.mjs';
+import { preferCurriedCall } from './prefer-curried-call.mjs';
 import { preferNonMutatingArrayMethod } from './prefer-non-mutating-array-method.mjs';
 
 export const tsRestrictionsRules = {
@@ -14,5 +15,6 @@ export const tsRestrictionsRules = {
   'no-string-spread': noStringSpread,
   'no-unnecessary-array-from': noUnnecessaryArrayFrom,
   'no-unnecessary-coalesce-undefined': noUnnecessaryCoalesceUndefined,
+  'prefer-curried-call': preferCurriedCall,
   'prefer-non-mutating-array-method': preferNonMutatingArrayMethod,
 } as const satisfies ESLintPlugin['rules'];

--- a/src/rules/eslint-ts-restrictions-rules.mts
+++ b/src/rules/eslint-ts-restrictions-rules.mts
@@ -9,6 +9,7 @@ export const eslintTsRestrictionsRules = {
   'ts-restrictions/no-string-spread': 'error',
   'ts-restrictions/no-unnecessary-array-from': 'error',
   'ts-restrictions/no-unnecessary-coalesce-undefined': 'error',
+  'ts-restrictions/prefer-curried-call': 'error',
   'ts-restrictions/prefer-non-mutating-array-method': 'error',
   'ts-restrictions/check-destructuring-completeness':
     withDefaultOption('error'),

--- a/src/types/rules/eslint-ts-restrictions-rules.mts
+++ b/src/types/rules/eslint-ts-restrictions-rules.mts
@@ -280,6 +280,21 @@ namespace NoUnnecessaryCoalesceUndefined {
 }
 
 /**
+ * @description Replace a redundant arrow wrapper with the function itself (`(a) => f(a)` → `f`) or, when the callee has a curried version, its curried form (`(a) => f(a, ...rest)` → `f(...rest)`).
+ *
+ *  ```md
+ *  | key        | value      |
+ *  | :--------- | :--------- |
+ *  | type       | suggestion |
+ *  | deprecated | false      |
+ *  | fixable    | code       |
+ *  ```
+ */
+namespace PreferCurriedCall {
+  export type RuleEntry = Linter.StringSeverity;
+}
+
+/**
  * @description Disallow calling a mutating array method on a defensive `Array.from()` copy of an array (e.g. `Array.from(x).sort()`); use the non-mutating counterpart on the original array instead (e.g. `x.toSorted()`)
  *
  *  ```md
@@ -301,6 +316,7 @@ export type EslintTsRestrictionsRules = Readonly<{
   'ts-restrictions/no-string-spread': NoStringSpread.RuleEntry;
   'ts-restrictions/no-unnecessary-array-from': NoUnnecessaryArrayFrom.RuleEntry;
   'ts-restrictions/no-unnecessary-coalesce-undefined': NoUnnecessaryCoalesceUndefined.RuleEntry;
+  'ts-restrictions/prefer-curried-call': PreferCurriedCall.RuleEntry;
   'ts-restrictions/prefer-non-mutating-array-method': PreferNonMutatingArrayMethod.RuleEntry;
 }>;
 


### PR DESCRIPTION
## Summary

Adds a type-aware, auto-fixable `ts-restrictions/prefer-curried-call` rule that rewrites a redundant arrow wrapper around a function call into a point-free form, using the callee's curried version when one exists:

- **Eta reduction** — `(a) => f(a)` → `f`, only when `f` is *effectively unary* (every call signature accepts at most one argument) and safe to reference as a bare value (a standalone function or a namespace member — never an instance method, which would lose its `this`). This is what keeps the classic `map((s) => parseInt(s))` footgun (where `parseInt` also reads the index) from being rewritten.
- **Curried form** — `(a) => f(a, ...rest)` → `f(...rest)`, only when `f` has a genuine curried signature (a call signature accepting `...rest` and returning a one-argument function) and the remaining arguments are side-effect-free (so hoisting them out of the wrapper cannot change evaluation semantics).

In all cases the arrow's single (unannotated) parameter must appear exactly once, as the first argument of the call, so dropping the wrapper is behavior-preserving.

The rule is general-purpose (not tied to any particular library), so it lives in `ts-restrictions` and is enabled as `error` in the recommended config.

## Changes

- New rule + tests: `src/plugins/ts-restrictions/rules/prefer-curried-call.{mts,test.mts}` (10 valid / 5 invalid cases).
- Registered in `rules.mts`, enabled in `src/rules/eslint-ts-restrictions-rules.mts`, and regenerated the rule types.
- Dogfooding surfaced (and this PR auto-fixes) two eta-reducible call sites: `total-functions/no-partial-division` and the rule-type generator.

## Validation

`tsc`, full `lint` (0 errors, whole repo with the rule active), the full Node test suite (771 tests), `cspell`, `check:ext`, `build`, `codemod:full` (no changes), and `doc` (no changes) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQWFy7Am26wXQ9V2rNThH8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQWFy7Am26wXQ9V2rNThH8)_