### PR TITLE
chore: replace doc generation step with fmt:diff in check-all

### DIFF
--- a/scripts/cmd/check-all.mts
+++ b/scripts/cmd/check-all.mts
@@ -51,9 +51,9 @@ const checkAll = async (): Promise<void> => {
   });
 
   await logStep({
-    startMessage: 'Generating documentation',
-    action: () => runCmdStep('pnpm run doc', 'Documentation generation failed'),
-    successMessage: 'Documentation generated',
+    startMessage: 'Formatting code',
+    action: () => runCmdStep('pnpm run fmt:diff', 'File formatting failed'),
+    successMessage: 'Code formatted',
   });
 
   await logStep({


### PR DESCRIPTION
## Summary
- Remove the typedoc documentation-generation step from the local `check-all` script.
- Add a `fmt:diff` formatting step (replacing `fmt:full` in monorepo repos).
- Add a `test:browser` step where a `test:browser` script exists.

This only affects the local `scripts/cmd/check-all.mts` convenience runner; CI is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)