### PR TITLE
chore: extend cspell scope to .changeset/.github and disable required code-owner review

### DIFF
--- a/.cspell.config.yaml
+++ b/.cspell.config.yaml
@@ -4,6 +4,8 @@ allowCompoundWords: true
 caseSensitive: false
 ignoreRandomStrings: true
 words:
+  - amannn
+  - anthropics
   - bivariant
   - blueprintjs
   - klass
@@ -15,6 +17,7 @@ words:
   - tses
   - tsutils
   - unshifted
+  - vitest
 ignorePaths:
   - pnpm-lock.yaml
   - pnpm-workspace.yaml

--- a/github/rulesets/main.json
+++ b/github/rulesets/main.json
@@ -37,7 +37,7 @@
         "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": true,
         "required_reviewers": [],
-        "require_code_owner_review": true,
+        "require_code_owner_review": false,
         "require_last_push_approval": false,
         "required_review_thread_resolution": true,
         "allowed_merge_methods": ["squash"]

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "codemod:uncommitted:any-to-unknown": "replace-any-with-unknown --uncommitted '{src,scripts,samples}/**/*.{mts,tsx}'",
     "codemod:uncommitted:unknown-record": "replace-record-with-unknown-record --uncommitted '{src,scripts,samples,test}/**/*.{mts,tsx}'",
     "codemod:uncommitted:interface-to-type": "convert-interface-to-type --uncommitted '{src,scripts,samples,test}/**/*.{mts,tsx}'",
-    "cspell": "cspell \"**\" --gitignore --gitignore-root ./ --no-progress",
+    "cspell": "cspell \"{**,.changeset/**/*,.github/**/*}\" --gitignore --gitignore-root ./ --no-progress",
     "doc": "tsx ./scripts/cmd/gen-docs.mts",
     "doc:embed": "tsx ./scripts/cmd/embed-examples.mts",
     "fmt": "format-uncommitted",


### PR DESCRIPTION
## Changes

- **cspell**: extend the scan glob to include `.changeset/**/*` and `.github/**/*` (previously excluded), so changeset files and workflow files are spell-checked going forward.
- **cspell dictionary**: add `amannn anthropics vitest` — words newly surfaced by the wider scan.
- **ruleset**: set `require_code_owner_review` to `false` in `github/rulesets/main.json` (was blocking Dependabot auto-merge). Only the active ruleset file is changed; `bk/` is a regenerated backup snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)