### PR TITLE
chore(ci): use REPO_AUTOMATION_BOT for release instead of the dedicated release App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.SEMANTIC_RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.SEMANTIC_RELEASE_BOT_PRIVATE_KEY }}
+          client-id: ${{ vars.REPO_AUTOMATION_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.REPO_AUTOMATION_BOT_PRIVATE_KEY }}
           # App が持つ全権限をそのまま受け取らないよう、release に必要な範囲へ明示的に絞る。
           permission-contents: write # コミット / タグ / GitHub Release の作成
           permission-pull-requests: write # リリース時の PR へのコメント


### PR DESCRIPTION
release 用の専用 App（ noshiro-changesets-release-bot / noshiro-semantic-release-bot ）を廃止し、`REPO_AUTOMATION_BOT` に統合します。リポジトリに置く GitHub App の秘密鍵が **3本 → 2本** になります。

token は既に `permission-contents: write` + `permission-pull-requests: write` に絞ってあるため、`REPO_AUTOMATION_BOT` が追加で `issues: write` を持っていても **release が受け取る実効権限は変わりません**。

セットアップ手順を記載した README / docs の参照名も併せて更新しています。