### PR TITLE
fix: turn off unicorn/no-unreadable-for-of-expression

### DIFF
--- a/src/rules/eslint-unicorn-rules.mts
+++ b/src/rules/eslint-unicorn-rules.mts
@@ -396,7 +396,15 @@ export const eslintUnicornRules = {
   'unicorn/no-unnecessary-boolean-comparison': 'error',
   'unicorn/no-unnecessary-fetch-options': 'error',
   'unicorn/no-unnecessary-string-trim': 'error',
-  'unicorn/no-unreadable-for-of-expression': 'error',
+  // Treats an argument as "complex" unless it is an identifier, a literal, a
+  // simple member expression or a *zero-argument* call, so
+  // `for (const i of range(asUint32(n), -1, -1))` is reported twice over: for
+  // the wrapped cast, and for `-1` (a `UnaryExpression`, not a `Literal`).
+  // Neither is unreadable, and branded-number APIs make wrapped casts the norm,
+  // so the rule mostly buys throwaway variables. Note also the inconsistency:
+  // unicorn's own `prefer-simple-condition-first` does accept signed numeric
+  // literals as simple.
+  'unicorn/no-unreadable-for-of-expression': 'off',
   'unicorn/no-unsafe-promise-all-settled-values': 'error',
   'unicorn/no-useless-coercion': 'error',
   'unicorn/no-useless-compound-assignment': 'error',


### PR DESCRIPTION
## Summary

Turns off `unicorn/no-unreadable-for-of-expression`, new in eslint-plugin-unicorn 72.0.0 and enabled automatically through `recommended`.

The rule accepts a `for…of` iterable expression only when **every argument** is an identifier, a literal, a simple member expression, or a **zero-argument** call. Two common shapes are rejected despite being perfectly readable:

```ts
for (const i of range(asUint32(n), -1, -1)) {
```

- `asUint32(n)` — a nested call that takes an argument (`f()` is fine, `f(1)` is not)
- `-1` — an ESTree `UnaryExpression`, not a `Literal`

## Verified behavior

Probed against the rule in isolation:

| expression | verdict |
| :--- | :--- |
| `range(n)` / `range(100)` / `range(1, 100)` | pass |
| `range(a.b)` / `range(this.x)` / `range(f())` | pass |
| `range(-1)` / `range(100, -1)` | **reported** |
| `range(f(1))` | **reported** |

Argument count is irrelevant — `range(1, 100)` passes. Only the two shapes above trigger it.

## Why off rather than configured

The rule has no options. Codebases built on branded-number APIs wrap nearly every numeric bound in a cast (`asUint32`, `asSafeInt`), so it fires on most non-trivial loops and buys nothing but a throwaway variable per loop — which reads worse than the expression it replaces.

Worth flagging an inconsistency inside unicorn itself: `prefer-simple-condition-first` explicitly classifies signed numeric literals as simple via `isSimpleOperand`, while `no-unreadable-for-of-expression` has no such case in `isSimpleArgumentExpression`. The `-1` rejection looks like an oversight rather than a design decision.

## Release impact

Typed `fix:` so semantic-release cuts a patch. `chore:` would not publish, and the change has to reach consumers — ts-data-forge currently carries a local override waiting on this release.

`pnpm run check-all` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)